### PR TITLE
Clicking link from profile projects doesn't throw error now

### DIFF
--- a/client/src/components/Projects/ProjectsContainer/ProjectsContainer.tsx
+++ b/client/src/components/Projects/ProjectsContainer/ProjectsContainer.tsx
@@ -64,19 +64,28 @@ class ProjectsContainer extends Component<any, any> {
     }
   }
 
+  /**
+   * Manages purple highlighting of the boxes when focused
+   * @param prevProps
+   * @param prevState
+   */
   componentDidUpdate(prevProps, prevState) {
     if (this.props.current_project !== prevProps.current_project) {
       if (prevProps.current_project) {
         // Reset the border of the old project
         const oldProjectId = prevProps.current_project._id;
         const oldProject = document.getElementById(oldProjectId);
-        oldProject.style.border = "1px solid rgba(0, 0, 0, 0.125)";
+        if (oldProject) {
+          oldProject.style.border = "1px solid rgba(0, 0, 0, 0.125)";
+        }
       }
 
       // Update the border of the selected project
       const projectid = this.props.current_project._id;
       const project = document.getElementById(projectid);
-      project.style.border = "1px solid #3246bb";
+      if (project) {
+        project.style.border = "1px solid #3246bb";
+      }
     }
   }
 


### PR DESCRIPTION
This sort of resolve issue #46 by preventing an error being thrown. The outline sometimes does not show up when clicking from a project link on the profile page.